### PR TITLE
Update(ts): 2027 conference deadlines and links

### DIFF
--- a/lib/conference-data.ts
+++ b/lib/conference-data.ts
@@ -179,7 +179,7 @@ export const allConferences: Conference[] = [
     {
         ...conferenceMetadata["Crypto"],
         deadline: "2026-02-12T23:59:59",
-        cycle: "(1 / 1)",
+        cycle: "(1 / 2)",
         year: 2026,
         location: "Santa Barbara, USA",
         link: "https://crypto.iacr.org/2026/",
@@ -200,7 +200,7 @@ export const allConferences: Conference[] = [
         ...conferenceMetadata["MICRO"],
         deadline: "2026-04-09T04:59:59",
         abstract: "2026-04-02",
-        cycle: "(1 / 1)",
+        cycle: "(1 / 2)",
         year: 2026,
         location: "Athens, Greece",
         link: "https://microarch.org/",
@@ -232,23 +232,22 @@ export const allConferences: Conference[] = [
     // Predicted / Future Cycles (Nearest Only)
     {
         ...conferenceMetadata["ASPLOS"],
-        deadline: "2026-02-28T23:59:59", // Predicted Spring Cycle
+        deadline: "2026-04-15T23:59:59",
+        abstract: "2026-04-08",
         cycle: "(1 / 2)",
         year: 2027,
-        location: "TBD",
-        link: "https://asplos-conference.org/",
-        isPredicted: true,
-        conferenceDate: "Mar 2027 (TBD)",
-        conferenceEndDate: "2027-03-31"
+        location: "Heraklion, Greece",
+        link: "https://www.asplos-conference.org/asplos2027/cfp/",
+        conferenceDate: "Apr 11-15, 2027",
+        conferenceEndDate: "2027-04-15"
     },
     {
         ...conferenceMetadata["NDSS"],
-        deadline: "2026-04-23T23:59:59",
-        cycle: "(1 / 2)",
+        deadline: "2026-05-06T23:59:59",
+        cycle: "(1 / 1)",
         year: 2027,
-        location: "San Diego, USA",
-        link: "https://www.ndss-symposium.org/",
-        isPredicted: true,
+        location: "TBD",
+        link: "https://www.ndss-symposium.org/ndss2027/submission-process/",
         conferenceDate: "Feb 2027 (TBD)",
         conferenceEndDate: "2027-02-28"
     },
@@ -257,7 +256,7 @@ export const allConferences: Conference[] = [
         deadline: "2026-05-30T23:59:59",
         cycle: "(1 / 1)", // Usually single cycle
         year: 2027,
-        location: "Sydney, Australia",
+        location: "Salt Lake City, USA",
         link: "https://conf.researchr.org/home/cgo-2027",
         isPredicted: true,
         conferenceDate: "Feb 2027 (TBD)",
@@ -265,15 +264,14 @@ export const allConferences: Conference[] = [
     },
     {
         ...conferenceMetadata["EuroSys"],
-        deadline: "2026-05-15T23:59:59",
-        abstract: "2026-05-08",
+        deadline: "2026-05-14T23:59:59",
+        abstract: "2026-05-07",
         cycle: "(1 / 2)",
         year: 2027,
-        location: "Edinburgh, UK",
-        link: "https://www.eurosys.org/",
-        isPredicted: true,
-        conferenceDate: "Apr 2027 (TBD)",
-        conferenceEndDate: "2027-04-30"
+        location: "Rabat, Morocco",
+        link: "https://2027.eurosys.org/",
+        conferenceDate: "Apr 19-23, 2027",
+        conferenceEndDate: "2027-04-23"
     },
     {
         ...conferenceMetadata["IEEE S&P"],
@@ -290,13 +288,13 @@ export const allConferences: Conference[] = [
     {
         ...conferenceMetadata["USENIX Security"],
         deadline: "2026-08-26T23:59:59",
+        abstract: "2026-08-19",
         cycle: "(1 / 2)",
         year: 2027,
-        location: "TBD",
+        location: "Denver, USA",
         link: "https://www.usenix.org/conference/usenixsecurity27",
-        isPredicted: true,
-        conferenceDate: "Aug 2027 (TBD)",
-        conferenceEndDate: "2027-08-31"
+        conferenceDate: "Aug 11-13, 2027",
+        conferenceEndDate: "2027-08-13"
     },
     {
         ...conferenceMetadata["OOPSLA"],
@@ -721,4 +719,3 @@ export const upcomingConferences = allConferences.filter(c =>
 export const pastConferences = allConferences.filter(c =>
     parseDeadline(c.deadline) <= new Date()
 )
-


### PR DESCRIPTION
### Motivation
- Bring the deadlines page data up-to-date by replacing predicted/TBD entries with confirmed CFP links, deadlines, and locations where available for 2027 conferences.
- Reflect the user-requested location change for CGO 2027 to Salt Lake City, USA.
- Improve accuracy of displayed submission deadlines and conference dates on the `/deadlines` page by updating the canonical source data.

### Description
- Updated `lib/conference-data.ts` entries for multiple 2027 conferences including `ASPLOS`, `NDSS`, `CGO`, `EuroSys`, and `USENIX Security` with revised `deadline`, `abstract`, `location`, `link`, `conferenceDate`, and `conferenceEndDate` fields as applicable.
- Set `CGO` 2027 `location` to `Salt Lake City, USA` and adjusted related metadata for confirmed CFP links where available.
- Replaced several `isPredicted`/TBD placeholders with concrete CFP URLs and dates (e.g., `ASPLOS` and `EuroSys`) and adjusted cycle values for some entries to match updated information.
- Minor deadline and cycle adjustments were made elsewhere in `lib/conference-data.ts` to keep data consistent with known CFP announcements.

### Testing
- Ran `npm run lint` and it completed successfully with a non-blocking ESLint warning unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87fc774d0832387ced4244d8c7813)